### PR TITLE
fix ArcService module import statement

### DIFF
--- a/src/txInfo/txInfo.ts
+++ b/src/txInfo/txInfo.ts
@@ -1,5 +1,5 @@
 import { autoinject } from "aurelia-framework";
-import { Hash, TransactionReceipt } from '../services/arcService';
+import { Hash, TransactionReceipt } from '../services/ArcService';
 import { Web3Service } from '../services/Web3Service';
 import { BlockWithoutTransactionData } from 'web3';
 


### PR DESCRIPTION
An incorrect reference to `'../services/arcService'` was causing a fresh build from master to fail.